### PR TITLE
Use real URL, taking care of default pages

### DIFF
--- a/collective/fbshare/browser/viewlet.py
+++ b/collective/fbshare/browser/viewlet.py
@@ -64,7 +64,6 @@ class OpenGraphMetaViewlet(SiteOpenGraphMetaViewlet):
         """Return URL to the image to be used for sharing
         """
         portal_state = getMultiAdapter((self.context, self.request), name=u'plone_portal_state')
-        context_state = getMultiAdapter((self.context, self.request), name=u'plone_context_state')
         registry = queryUtility(IRegistry)
         settings = registry.forInterface(IFbShareSettings, check=False)
 
@@ -72,7 +71,7 @@ class OpenGraphMetaViewlet(SiteOpenGraphMetaViewlet):
             # Stolen from collective.opengraph
             img_size = settings.content_image_size
             context = aq_inner(self.context)
-            obj_url = context_state.canonical_object_url()
+            obj_url = context.absolute_url()
             if hasattr(context, 'getField'):
                 field = self.context.getField('image')
                 if not field and HAS_LEADIMAGE:


### PR DESCRIPTION
Actually just one fix in opengraph_meta.pt

```
    <meta property="og:url" content="URL of this object"
          tal:attributes="content context/@@plone_context_state/canonical_object_url" />
```

Using the /canonical_object_url instead of Zope's absolute_url in order to handle "default pages" of folders (e.g. I want to share /events not /events/aggregator)
